### PR TITLE
Sync Vulnerability DNA Across OSV and NVD

### DIFF
--- a/agent/api_manager/osv_service_api.py
+++ b/agent/api_manager/osv_service_api.py
@@ -1,5 +1,6 @@
 """This module provides utility functions to query the OSV API for vulnerability information
 related to a specific package version."""
+
 import dataclasses
 import logging
 from typing import Any

--- a/agent/cve_service_api.py
+++ b/agent/cve_service_api.py
@@ -1,4 +1,5 @@
 """module responsible for retrieving the risk rating of a vulnerability"""
+
 import dataclasses
 import json
 

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -1,4 +1,5 @@
 """OSV agent implementation"""
+
 import json
 import logging
 import pathlib
@@ -141,6 +142,7 @@ class OSVAgent(
             self.report_vulnerability(
                 entry=vuln.entry,
                 technical_detail=vuln.technical_detail,
+                dna=vuln.dna,
                 risk_rating=vuln.risk_rating,
             )
 

--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -1,4 +1,5 @@
 """OSV Wrapper responsible for dealing with the agent output and constructing its information."""
+
 import dataclasses
 import json
 import logging
@@ -39,6 +40,7 @@ class Vulnerability:
     """Vulnerability dataclass to pass to the emit method."""
 
     entry: kb.Entry
+    dna: str
     technical_detail: str
     risk_rating: agent_report_vulnerability_mixin.RiskRating
 
@@ -380,6 +382,7 @@ def construct_vuln(
                 targeted_by_nation_state=False,
                 recommendation=recommendation,
             ),
+            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}_{vuln.package_version}",
             technical_detail=technical_detail,
             risk_rating=agent_report_vulnerability_mixin.RiskRating[
                 vuln.risk.upper()

--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -382,7 +382,7 @@ def construct_vuln(
                 targeted_by_nation_state=False,
                 recommendation=recommendation,
             ),
-            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}_{vuln.package_version}",
+            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}",
             technical_detail=technical_detail,
             risk_rating=agent_report_vulnerability_mixin.RiskRating[
                 vuln.risk.upper()

--- a/tests/calculate_risk_rating_test.py
+++ b/tests/calculate_risk_rating_test.py
@@ -1,4 +1,5 @@
 """Unittests for calculating risk rating."""
+
 import pytest
 
 from agent import osv_output_handler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest fixture for the osv agent."""
+
 import json
 import pathlib
 import random

--- a/tests/cve_service_api_test.py
+++ b/tests/cve_service_api_test.py
@@ -1,4 +1,5 @@
 """Unittests for CVE service api."""
+
 import re
 
 import requests_mock as rq_mock

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -1,4 +1,5 @@
 """Unittests for OSV agent."""
+
 import subprocess
 from typing import Callable, Any
 
@@ -48,6 +49,10 @@ def testAgentOSV_whenAnalysisRunsWithoutPathWithContent_processMessage(
     assert (
         agent_mock[0].data["title"]
         == "Use of Outdated Vulnerable Component: protobuf@3.20.1: CVE-2022-1941"
+    )
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: protobuf@3.20.1"
     )
     assert agent_mock[0].data["risk_rating"] == "HIGH"
 
@@ -204,6 +209,10 @@ def testAgentOSV_whenFingerprintMessage_processMessage(
         == "Use of Outdated Vulnerable Component: lodash@4.7.11: CVE-2018-3721, CVE-2018-16487, CVE-2019-1010266, CVE-2019-10744, CVE-2020-8203, CVE-2020-28500, CVE-2021-23337"
     )
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: lodash@4.7.11"
+    )
 
 
 def testAgentOSV_whenRiskLowerCase_doesNotCrash(
@@ -228,6 +237,11 @@ def testAgentOSV_whenRiskLowerCase_doesNotCrash(
         agent_mock[0].data["title"]
         == "Use of Outdated Vulnerable Component: lodash@4.7.11: CVE-2018-3721, CVE-2018-16487, CVE-2019-1010266, CVE-2019-10744, CVE-2020-8203, CVE-2020-28500, CVE-2021-23337"
     )
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: lodash@4.7.11"
+    )
+
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
     assert (
         """- [CVE-2018-3721](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721) : Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. 
@@ -273,6 +287,10 @@ def testAgentOSV_whenMultipleVulns_groupByFingerprint(
         agent_mock[0].data["title"]
         == "Use of Outdated Vulnerable Component: lodash@4.7.11: CVE-2018-3721, CVE-2018-16487, CVE-2019-1010266, CVE-2019-10744, CVE-2020-8203, CVE-2020-28500, CVE-2021-23337"
     )
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: lodash@4.7.11"
+    )
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
     assert (
         """- [CVE-2018-3721](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721) : Versions of `lodash` before 4.17.5 are vulnerable to prototype pollution. 
@@ -304,6 +322,10 @@ def testAgentOSV_always_emitVulnWithValidTechnicalDetail(
     assert (
         agent_mock[0].data["title"]
         == "Use of Outdated Vulnerable Component: opencv@6.0.0: CVE-2019-10061"
+    )
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: opencv@6.0.0"
     )
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
     assert (
@@ -393,6 +415,10 @@ def testAgentOSV_whenPathInMessage_technicalDetailShouldIncludeIt(
     assert (
         agent_mock[0].data["title"]
         == "Use of Outdated Vulnerable Component: opencv@3.4.0: CVE-2019-10061"
+    )
+    assert (
+        agent_mock[0].data["dna"]
+        == "Use of Outdated Vulnerable Component: opencv@3.4.0"
     )
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
     assert agent_mock[0].data["technical_detail"] == (

--- a/tests/osv_wrapper_test.py
+++ b/tests/osv_wrapper_test.py
@@ -1,4 +1,5 @@
 """Unittests for OSV wrapper."""
+
 import json
 
 import pytest


### PR DESCRIPTION
Related Ticket: [OS-7939](https://report.ostorlab.co/remediation/tickets/os-7939)

The default DNA values are based solely on technical details, leading to potential duplicates in reporting for the same vulnerability associated with a particular library version.

By implementing this fix, we ensure that vulnerabilities reported by both OSV and NVD with different technical details but corresponding to the same issue for a library version are marked consistently. This helps in reducing duplicate entries and ensures more efficient vulnerability management.

Please note that while this fix may result in missing other findings for the same library/version stored in OSV/NVD.

Related PR: [agent_vulnz_matcher/pull/11](https://github.com/Ostorlab/agent_vulnz_matcher/pull/11)