### PR TITLE
Fix for Hidden Information in Technical Details

### DIFF
--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -400,7 +400,7 @@ def construct_vuln(
             "## Recommendation\n\n", "Recommendation: "
         )
         if len(vuln.cves) == 0:
-            technical_detail += f"- **Description**:\n```{osv_description}\n```"
+            technical_detail += f"- **Description**:\n```\n{osv_description}\n```"
         else:
             technical_detail += f"- **Description**:\n{osv_description}\n"
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: osv
-version: 0.6.1
+version: 0.6.2
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [OSV Scanner](https://github.com/google/osv-scanner).
 license: Apache-2.0

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -565,7 +565,7 @@ def testAgentOSV_whenElfLibraryFingerprintMessage_shouldExcludeNpmEcosystemVulnz
     )
     assert agent_mock[0].data["risk_rating"] == "POTENTIALLY"
     assert agent_mock[0].data["technical_detail"] == (
-        """#### Dependency `opencv`:\n- **Version**: `4.9.0`\n- **Description**:\n```- OSV-2022-394 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47190\n\n```\nCrash type: Incorrect-function-pointer-type\nCrash state:\ncv::split\ncv::split\nTestSplitAndMerge\n```\n\n- OSV-2023-444 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59450\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nopj_jp2_apply_pclr\nopj_jp2_decode\ncv::detail::Jpeg2KOpjDecoderBase::readData\n```\n\n\n```"""
+        """#### Dependency `opencv`:\n- **Version**: `4.9.0`\n- **Description**:\n```\n- OSV-2022-394 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47190\n\n```\nCrash type: Incorrect-function-pointer-type\nCrash state:\ncv::split\ncv::split\nTestSplitAndMerge\n```\n\n- OSV-2023-444 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59450\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nopj_jp2_apply_pclr\nopj_jp2_decode\ncv::detail::Jpeg2KOpjDecoderBase::readData\n```\n\n\n```"""
     )
     assert agent_mock[0].data["description"] == (
         """Dependency `opencv` with version `4.9.0` has a security issue."""


### PR DESCRIPTION
This pull request addresses an issue where technical details were not properly displayed due to a missing line break, resulting in hidden information in the UI.

#### Issue:
As shown in the screenshot below, the lack of a break line caused important information to be hidden:

**Before the fix:**
![image](https://github.com/user-attachments/assets/baed6d5f-fddd-4bc0-abbe-2c84756703cc)

#### Solution:
A line break has been added to ensure all information is correctly displayed in the technical details section.

**After the fix:**
![image](https://github.com/user-attachments/assets/7597e444-7ca8-439a-8a0f-08a64469ad85)

#### Ticket Reference:
For more details, see the associated ticket: [OS-11714](https://report.ostorlab.co/remediation/tickets/os-11714).