### PR TITLE
Match DNA generation with vulnz_matcher

### DIFF
--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -419,7 +419,7 @@ def construct_vuln(
                 targeted_by_nation_state=False,
                 recommendation=recommendation,
             ),
-            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}: {','.join(vuln.cves[:MAX_SHOWN_CVES])}",
+            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}: {','.join(vuln.cves[:MAX_SHOWN_CVES])}{f' {path}' if path is not None else ''}",
             technical_detail=technical_detail,
             risk_rating=agent_report_vulnerability_mixin.RiskRating[
                 vuln.risk.upper()

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -514,7 +514,7 @@ def testAgentOSV_whenPathInMessage_technicalDetailShouldIncludeIt(
     )
     assert (
         agent_mock[0].data["dna"]
-        == "Use of Outdated Vulnerable Component: opencv@3.4.0: CVE-2019-10061"
+        == "Use of Outdated Vulnerable Component: opencv@3.4.0: CVE-2019-10061 `lib/arm64-v8a/libBlinkID.so`"
     )
     assert agent_mock[0].data["risk_rating"] == "CRITICAL"
     assert agent_mock[0].data["technical_detail"] == (


### PR DESCRIPTION
The DNA of the vulnerabilities reported by `OSV` does not contain paths like those in the `vulnz_matcher`.
Also the CVEs in the two findings are not identical some are common, while others are unique to each finding.
Scan: https://report.ostorlab.co/scan/125255/
Vuln 1: https://report.ostorlab.co/scan/125255/vuln/25060/risk/critical
Vuln 2: https://report.ostorlab.co/scan/125255/vuln/29640/risk/info

⚠️ So this fix will guarantee the same method of DNA generation, but not the same DNA if the CVEs are different.