### PR TITLE
Query OSV with lowercase package names in case uppercase return empty…

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -282,6 +282,13 @@ class OSVAgent(
         )
 
         if api_result is None or api_result == {}:
+            api_result = osv_service_api.query_osv_api(
+                package_name=package_name.lower(),
+                version=package_version,
+                ecosystem=ecosystem,
+            )
+
+        if api_result is None or api_result == {}:
             return None
 
         parsed_osv_output = osv_output_handler.parse_vulnerabilities_osv_api(


### PR DESCRIPTION
PR Title: Handle Case-sensitive Package Names in OSV API Query for Vulnerability Detection
Description:
This PR improves the _process_fingerprint_file method in the OSVAgent to handle case-sensitive package names when querying vulnerabilities through the OSV API.

Key Changes:
Added Fallback API Query: If the OSV API query returns an empty result when the package name is uppercase (e.g., Wordpress), the agent will retry the query with the package name in lowercase (e.g., wordpress). This allows for more robust handling of case-sensitive package names in vulnerability queries.