### PR TITLE
feature: Ignore dev dependencies when running osv command.

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -144,6 +144,7 @@ def _construct_commands(file_path: str) -> list[list[str]]:
     return [
         [
             "/usr/local/bin/osv-scanner",
+            "--ignore-dev",
             "--format",
             "json",
             "--lockfile",
@@ -151,6 +152,7 @@ def _construct_commands(file_path: str) -> list[list[str]]:
         ],
         [
             "/usr/local/bin/osv-scanner",
+            "--ignore-dev",
             "--format",
             "json",
             "--sbom",

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -43,7 +43,7 @@ def testAgentOSV_whenAnalysisRunsWithoutPathWithContent_processMessage(
 
     test_agent.process(scan_message_file)
 
-    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
         subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0
@@ -89,7 +89,7 @@ def testAgentOSV_whenAnalysisRunsWithoutURL_processMessage(
 
     test_agent.process(scan_message_link)
 
-    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
         subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0
@@ -135,7 +135,7 @@ def testAgentOSV_whenAnalysisRunsWithBadFile_noCrash(
 
     test_agent.process(scan_message_bad_file)
 
-    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
         subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -43,8 +43,9 @@ def testAgentOSV_whenAnalysisRunsWithoutPathWithContent_processMessage(
 
     test_agent.process(scan_message_file)
 
-    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
-        subprocess_mock.call_args.args[0]
+    assert (
+        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
+        in " ".join(subprocess_mock.call_args.args[0])
     )
     assert len(agent_mock) > 0
     assert (
@@ -89,8 +90,9 @@ def testAgentOSV_whenAnalysisRunsWithoutURL_processMessage(
 
     test_agent.process(scan_message_link)
 
-    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
-        subprocess_mock.call_args.args[0]
+    assert (
+        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
+        in " ".join(subprocess_mock.call_args.args[0])
     )
     assert len(agent_mock) > 0
     assert (
@@ -135,8 +137,9 @@ def testAgentOSV_whenAnalysisRunsWithBadFile_noCrash(
 
     test_agent.process(scan_message_bad_file)
 
-    assert "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile" in " ".join(
-        subprocess_mock.call_args.args[0]
+    assert (
+        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
+        in " ".join(subprocess_mock.call_args.args[0])
     )
     assert len(agent_mock) > 0
 


### PR DESCRIPTION
OSV scanner supports a flag to ignore dev dependencies.

This PR passes the argument to avoid reporting issues in dev dependencies.
