### PR TITLE
Revert "feature: Ignore dev dependencies when running osv command."

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -144,7 +144,6 @@ def _construct_commands(file_path: str) -> list[list[str]]:
     return [
         [
             "/usr/local/bin/osv-scanner",
-            "--ignore-dev",
             "--format",
             "json",
             "--lockfile",
@@ -152,7 +151,6 @@ def _construct_commands(file_path: str) -> list[list[str]]:
         ],
         [
             "/usr/local/bin/osv-scanner",
-            "--ignore-dev",
             "--format",
             "json",
             "--sbom",

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -43,9 +43,8 @@ def testAgentOSV_whenAnalysisRunsWithoutPathWithContent_processMessage(
 
     test_agent.process(scan_message_file)
 
-    assert (
-        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
-        in " ".join(subprocess_mock.call_args.args[0])
+    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+        subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0
     assert (
@@ -90,9 +89,8 @@ def testAgentOSV_whenAnalysisRunsWithoutURL_processMessage(
 
     test_agent.process(scan_message_link)
 
-    assert (
-        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
-        in " ".join(subprocess_mock.call_args.args[0])
+    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+        subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0
     assert (
@@ -137,9 +135,8 @@ def testAgentOSV_whenAnalysisRunsWithBadFile_noCrash(
 
     test_agent.process(scan_message_bad_file)
 
-    assert (
-        "/usr/local/bin/osv-scanner --ignore-dev --format json --lockfile"
-        in " ".join(subprocess_mock.call_args.args[0])
+    assert "/usr/local/bin/osv-scanner --format json --lockfile" in " ".join(
+        subprocess_mock.call_args.args[0]
     )
     assert len(agent_mock) > 0
 


### PR DESCRIPTION
Reverts Ostorlab/agent_osv#71 because "--ignore-dev" flag isn't supported in `scan` command