### PR TITLE
fix: preserve directory context for Go module files 

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -184,6 +184,37 @@ def _run_osv(path: str, content: bytes) -> str | None:
     return None
 
 
+def _run_osv_directory(original_path: str, content: bytes) -> str | None:
+    """Perform OSV scan on a directory (for Go projects) to preserve context.
+    
+    Args:
+        original_path: Original file path (e.g., "/workspace/go.mod")
+        content: File content as bytes
+        
+    Returns:
+        OSV scan results as JSON string, or None if scan fails
+    """
+    try:
+        original_path_obj = pathlib.Path(original_path)
+        module_dir = original_path_obj.parent.resolve()
+        
+        # Write file to module directory
+        patched_path, patched_content = hotpatch.hotpatch(original_path_obj.name, content)
+        file_path = module_dir / original_path_obj.name
+        file_path.write_text(patched_content.decode("utf-8", errors="ignore"), encoding="utf-8")
+        
+        # Scan directory instead of just the file
+        command = ["/usr/local/bin/osv-scanner", "--format", "json", str(module_dir)]
+        output = subprocess.run(command, cwd=module_dir, capture_output=True, text=True, check=False)
+        
+        if _is_valid_osv_result(output.stdout):
+            return output.stdout
+        return None
+    except Exception as e:
+        logger.error("Error during directory scan: %s", e, exc_info=True)
+        return None
+
+
 def _get_file_type(content: bytes, path: str | None) -> str:
     if path is None:
         mime = magic.from_buffer(content, mime=True)
@@ -302,6 +333,22 @@ class OSVAgent(
         if file_type in FILE_TYPE_BLACKLIST:
             logger.debug("File type is blacklisted.")
             return
+        
+        # Special handling for Go module files to preserve directory context
+        if path and path.endswith(("go.mod", "go.sum")):
+            scan_results = _run_osv_directory(path, content)
+            if scan_results is not None:
+                parsed_output = osv_output_handler.parse_osv_output(
+                    scan_results, self.api_key
+                )
+                if len(parsed_output) > 0:
+                    vulnerability_location = _prepare_vulnerability_location(message)
+                    self._emit_vulnerabilities(
+                        output=parsed_output,
+                        vulnerability_location=vulnerability_location,
+                    )
+            return
+        
         for file_name in SUPPORTED_OSV_FILE_NAMES:
             scan_results = _run_osv(file_name, content)
             if scan_results is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,3 +267,60 @@ def elf_library_fingerprint_msg() -> message.Message:
         "library_type": "ELF_LIBRARY",
     }
     return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def go_mod_file_message() -> message.Message:
+    """Creates a dummy message of type v3.asset.file for go.mod file."""
+    selector = "v3.asset.file"
+    go_mod_content = b"""module example.com/myapp
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.9.0
+)
+"""
+    msg_data = {"content": go_mod_content, "path": "/workspace/go.mod"}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def go_sum_file_message() -> message.Message:
+    """Creates a dummy message of type v3.asset.file for go.sum file."""
+    selector = "v3.asset.file"
+    go_sum_content = b"""github.com/gin-gonic/gin v1.9.0 h1:test
+github.com/gin-gonic/gin v1.9.0/go.mod h1:test
+"""
+    msg_data = {"content": go_sum_content, "path": "/workspace/go.sum"}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def fake_go_osv_output() -> str:
+    """Return fake OSV output for Go module scanning."""
+    return json.dumps(
+        {
+            "results": [
+                {
+                    "source": {"path": "/workspace/go.mod", "type": "lockfile"},
+                    "packages": [
+                        {
+                            "package": {
+                                "name": "github.com/gin-gonic/gin",
+                                "version": "1.9.0",
+                                "ecosystem": "Go",
+                            },
+                            "vulnerabilities": [
+                                {
+                                    "id": "GO-2024-1234",
+                                    "aliases": ["CVE-2024-1234"],
+                                    "summary": "Test vulnerability in gin",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    )

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -9,6 +9,7 @@ from pytest_mock import plugin
 
 from agent import cve_service_api
 from agent import osv_agent
+from agent import osv_output_handler
 from agent.api_manager import osv_service_api
 
 
@@ -734,3 +735,178 @@ def testAgentOSV_whenAndroidMetadataWithPackageName_prepareVulnerabilityLocation
         .get("value")
         == "/tmp/path/file.txt"
     )
+
+
+def testRunOsvDirectory_whenGoModFile_scansDirectory(
+    mocker: plugin.MockerFixture,
+    fake_go_osv_output: str,
+    tmp_path: Any,
+) -> None:
+    """Unit test for _run_osv_directory function with go.mod file."""
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    go_mod_path = str(workspace_dir / "go.mod")
+    go_mod_content = b"module example.com/myapp\n\ngo 1.21\n"
+
+    mock_subprocess = mocker.Mock()
+    mock_subprocess.stdout = fake_go_osv_output
+    mocker.patch("subprocess.run", return_value=mock_subprocess)
+    mocker.patch("agent.hotpatch.hotpatch", return_value=("go.mod", go_mod_content))
+
+    result = osv_agent._run_osv_directory(go_mod_path, go_mod_content)
+
+    assert result is not None
+    assert result == fake_go_osv_output
+    subprocess_call = subprocess.run
+    assert subprocess_call.call_count == 1
+    call_args = subprocess_call.call_args
+    assert call_args[0][0][0] == "/usr/local/bin/osv-scanner"
+    assert call_args[0][0][1] == "--format"
+    assert call_args[0][0][2] == "json"
+    assert str(workspace_dir) in call_args[0][0][3]
+
+
+def testRunOsvDirectory_whenSubprocessFails_returnsNone(
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Unit test for _run_osv_directory when subprocess fails."""
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    go_mod_path = str(workspace_dir / "go.mod")
+    go_mod_content = b"module example.com/myapp\n"
+
+    mock_subprocess = mocker.Mock()
+    mock_subprocess.stdout = '{"results": []}'
+    mocker.patch("subprocess.run", return_value=mock_subprocess)
+    mocker.patch("agent.hotpatch.hotpatch", return_value=("go.mod", go_mod_content))
+
+    result = osv_agent._run_osv_directory(go_mod_path, go_mod_content)
+
+    assert result is None
+
+
+def testRunOsvDirectory_whenExceptionOccurs_returnsNone(
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    go_mod_path = str(workspace_dir / "go.mod")
+    go_mod_content = b"module example.com/myapp\n"
+
+    mocker.patch("subprocess.run", side_effect=OSError("Test error"))
+    mocker.patch("agent.hotpatch.hotpatch", return_value=("go.mod", go_mod_content))
+
+    result = osv_agent._run_osv_directory(go_mod_path, go_mod_content)
+
+    assert result is None
+
+
+def testAgentOSV_whenGoModFile_usesDirectoryScanning(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    go_mod_file_message: message.Message,
+    mocker: plugin.MockerFixture,
+    fake_go_osv_output: str,
+) -> None:
+    """Unit test for OSV agent processing go.mod file using directory scanning."""
+    vuln_data = osv_output_handler.VulnData(
+        package_name="github.com/gin-gonic/gin",
+        package_version="1.9.0",
+        risk="HIGH",
+        description="Test vulnerability in gin",
+        summary="Test vulnerability",
+        fixed_version="1.9.1",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+
+    directory_scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv_directory", return_value=fake_go_osv_output
+    )
+    mocker.patch(
+        "agent.osv_output_handler.parse_osv_output",
+        return_value=[vuln_data],
+    )
+    mocker.patch("agent.osv_output_handler.calculate_risk_rating", return_value="HIGH")
+
+    test_agent.process(go_mod_file_message)
+
+    assert directory_scan_mock.call_count == 1
+    call_args = directory_scan_mock.call_args
+    assert "/workspace/go.mod" in call_args[0][0]
+    assert b"module example.com/myapp" in call_args[0][1]
+
+
+def testAgentOSV_whenGoSumFile_usesDirectoryScanning(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    go_sum_file_message: message.Message,
+    mocker: plugin.MockerFixture,
+    fake_go_osv_output: str,
+) -> None:
+    """Unit test for OSV agent processing go.sum file using directory scanning."""
+    vuln_data = osv_output_handler.VulnData(
+        package_name="github.com/gin-gonic/gin",
+        package_version="1.9.0",
+        risk="HIGH",
+        description="Test vulnerability in gin",
+        summary="Test vulnerability",
+        fixed_version="1.9.1",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+
+    directory_scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv_directory", return_value=fake_go_osv_output
+    )
+    mocker.patch(
+        "agent.osv_output_handler.parse_osv_output",
+        return_value=[vuln_data],
+    )
+    mocker.patch("agent.osv_output_handler.calculate_risk_rating", return_value="HIGH")
+
+    test_agent.process(go_sum_file_message)
+
+    assert directory_scan_mock.call_count == 1
+    call_args = directory_scan_mock.call_args
+    assert "/workspace/go.sum" in call_args[0][0]
+
+
+def testAgentOSV_whenGoModFileWithNoVulnerabilities_doesNotEmit(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    go_mod_file_message: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Unit test for OSV agent when go.mod scan finds no vulnerabilities."""
+    mocker.patch("agent.osv_agent._run_osv_directory", return_value='{"results": []}')
+    mocker.patch(
+        "agent.osv_output_handler.parse_osv_output",
+        return_value=[],
+    )
+
+    test_agent.process(go_mod_file_message)
+
+    assert len(agent_mock) == 0
+
+
+def testAgentOSV_whenGoModFileScanFails_doesNotEmit(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    go_mod_file_message: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Unit test for OSV agent when go.mod scan fails."""
+    mocker.patch("agent.osv_agent._run_osv_directory", return_value=None)
+
+    test_agent.process(go_mod_file_message)
+
+    assert len(agent_mock) == 0

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -750,16 +750,15 @@ def testRunOsvDirectory_whenGoModFile_scansDirectory(
 
     mock_subprocess = mocker.Mock()
     mock_subprocess.stdout = fake_go_osv_output
-    mocker.patch("subprocess.run", return_value=mock_subprocess)
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=mock_subprocess)
     mocker.patch("agent.hotpatch.hotpatch", return_value=("go.mod", go_mod_content))
 
     result = osv_agent._run_osv_directory(go_mod_path, go_mod_content)
 
     assert result is not None
     assert result == fake_go_osv_output
-    subprocess_call = subprocess.run
-    assert subprocess_call.call_count == 1
-    call_args = subprocess_call.call_args
+    assert mock_subprocess_run.call_count == 1
+    call_args = mock_subprocess_run.call_args
     assert call_args[0][0][0] == "/usr/local/bin/osv-scanner"
     assert call_args[0][0][1] == "--format"
     assert call_args[0][0][2] == "json"


### PR DESCRIPTION
- Add _run_osv_directory() to scan Go projects by directory instead of lockfile
- Early detection of go.mod/go.sum files in _process_asset()
- Preserves access to go.sum and module structure
- Backward compatible: all other file types use existing logic

Fixes context loss issue where OSV agent couldn't access go.sum when scanning Go projects. Now uses directory scanning (osv-scanner <dir>) instead of lockfile scanning (osv-scanner --lockfile go.mod) for Go files.

Changes: +47 lines in agent/osv_agent.py