### PR TITLE
feature: Add support of repository asset in agent_osv

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -251,7 +251,7 @@ def _run_osv_existing_directory(existing_path: str) -> str | None:
         output = subprocess.run(
             command, cwd=module_dir, capture_output=True, text=True, check=False
         )
-        if _is_valid_osv_result(output.stdout):
+        if _is_valid_osv_result(output.stdout) is True:
             return output.stdout
         return None
     except (OSError, UnicodeDecodeError, ValueError) as e:

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -425,19 +425,18 @@ class OSVAgent(
 
                 found_supported_file = True
                 file_path = pathlib.Path(root) / file_name
-
-                try:
-                    content = file_path.read_bytes()
-                except OSError as error:
-                    logger.warning(
-                        "Failed to read repository file %s: %s", file_path, error
-                    )
-                    continue
-
                 relative_path = str(file_path.relative_to(repository_path))
+
                 if file_path.name.lower() in ("go.mod", "go.sum"):
                     scan_results = _run_osv_existing_directory(str(file_path))
                 else:
+                    try:
+                        content = file_path.read_bytes()
+                    except OSError as error:
+                        logger.warning(
+                            "Failed to read repository file %s: %s", file_path, error
+                        )
+                        continue
                     scan_results = _run_osv(file_path.name, content)
 
                 if scan_results is None:

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -241,13 +241,12 @@ def _run_osv_directory(original_path: str, content: bytes) -> str | None:
 
 
 def _run_osv_existing_directory(existing_path: str) -> str | None:
-    """Perform OSV scan on the parent directory of an existing file.
+    """Perform OSV scan on the parent directory of a Go file already on disk.
 
-    This is used for repository assets where files are already mounted on disk.
+    Used for repository assets where files are mounted read-only; no writing needed.
     """
     try:
-        existing_path_obj = pathlib.Path(existing_path)
-        module_dir = existing_path_obj.parent.resolve()
+        module_dir = pathlib.Path(existing_path).parent.resolve()
         command = ["/usr/local/bin/osv-scanner", "--format", "json", str(module_dir)]
         output = subprocess.run(
             command, cwd=module_dir, capture_output=True, text=True, check=False
@@ -258,23 +257,6 @@ def _run_osv_existing_directory(existing_path: str) -> str | None:
     except (OSError, UnicodeDecodeError, ValueError) as e:
         logger.error("Error during existing directory scan: %s", e, exc_info=True)
         return None
-
-
-def _scan_dependency_file(
-    file_name: str,
-    content: bytes,
-    file_path: str | None = None,
-    existing_on_disk: bool = False,
-) -> str | None:
-    """Scan one dependency file and route Go files to directory scans."""
-    normalized_file_name = file_name.lower()
-    if normalized_file_name in ("go.mod", "go.sum"):
-        if file_path is None:
-            return None
-        if existing_on_disk:
-            return _run_osv_existing_directory(file_path)
-        return _run_osv_directory(file_path, content)
-    return _run_osv(file_name, content)
 
 
 def _get_file_type(content: bytes, path: str | None) -> str:
@@ -431,17 +413,11 @@ class OSVAgent(
             )
             return
 
-        supported_file_names_lower = [
-            supported_file.lower() for supported_file in SUPPORTED_OSV_FILE_NAMES
-        ]
+        supported_file_names_lower = {f.lower() for f in SUPPORTED_OSV_FILE_NAMES}
         found_supported_file = False
 
         for root, dirs, files in os.walk(repository_path, topdown=True):
-            dirs[:] = [
-                directory
-                for directory in dirs
-                if directory not in REPOSITORY_DIR_BLACKLIST
-            ]
+            dirs[:] = [d for d in dirs if d.lower() not in REPOSITORY_DIR_BLACKLIST]
 
             for file_name in files:
                 if file_name.lower() not in supported_file_names_lower:
@@ -459,12 +435,11 @@ class OSVAgent(
                     continue
 
                 relative_path = str(file_path.relative_to(repository_path))
-                scan_results = _scan_dependency_file(
-                    file_name=file_path.name,
-                    content=content,
-                    file_path=str(file_path),
-                    existing_on_disk=True,
-                )
+                if file_path.name.lower() in ("go.mod", "go.sum"):
+                    scan_results = _run_osv_existing_directory(str(file_path))
+                else:
+                    scan_results = _run_osv(file_path.name, content)
+
                 if scan_results is None:
                     continue
 
@@ -509,27 +484,21 @@ class OSVAgent(
 
         # Special handling for Go module files to preserve directory context
         if path is not None and path.endswith(("go.mod", "go.sum")) is True:
-            scan_results = _scan_dependency_file(
-                file_name=pathlib.Path(path).name,
-                content=content,
-                file_path=path,
-            )
-            if scan_results is None:
-                return
-
-            parsed_output = osv_output_handler.parse_osv_output(
-                scan_results, self.api_key
-            )
-            if len(parsed_output) > 0:
-                vulnerability_location = _prepare_vulnerability_location(message)
-                self._emit_vulnerabilities(
-                    output=parsed_output,
-                    vulnerability_location=vulnerability_location,
+            scan_results = _run_osv_directory(path, content)
+            if scan_results is not None:
+                parsed_output = osv_output_handler.parse_osv_output(
+                    scan_results, self.api_key
                 )
+                if len(parsed_output) > 0:
+                    vulnerability_location = _prepare_vulnerability_location(message)
+                    self._emit_vulnerabilities(
+                        output=parsed_output,
+                        vulnerability_location=vulnerability_location,
+                    )
             return
 
         for file_name in SUPPORTED_OSV_FILE_NAMES:
-            scan_results = _scan_dependency_file(file_name=file_name, content=content)
+            scan_results = _run_osv(file_name, content)
             if scan_results is not None:
                 logger.info(
                     "Found valid name for file: %s in path: %s", file_name, path

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -24,6 +24,7 @@ from agent.api_manager import osv_service_api
 from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
 from ostorlab.assets import domain_name
+from ostorlab.assets import repository as repository_asset
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
 
 
@@ -49,6 +50,10 @@ SUPPORTED_OSV_FILE_NAMES = [
     "yarn.lock",
     "verification-metadata.xml",
 ]
+
+SUPPORTED_OSV_FILE_NAMES_LOWER = {
+    file_name.lower() for file_name in SUPPORTED_OSV_FILE_NAMES
+}
 
 OSV_ECOSYSTEM_MAPPING = {
     "JAVASCRIPT_LIBRARY": ["npm"],
@@ -85,6 +90,8 @@ FILE_TYPE_BLACKLIST = (
     ".woff2",
     ".zip",
 )
+
+REPOSITORY_CODE_PATH = "/code"
 
 logging.basicConfig(
     format="%(message)s",
@@ -236,6 +243,7 @@ def _get_file_type(content: bytes, path: str | None) -> str:
 
 def _prepare_vulnerability_location(
     message: m.Message,
+    path: str | None = None,
 ) -> vuln_mixin.VulnerabilityLocation | None:
     """
     Prepare the vulnerability location based on the message data.
@@ -247,10 +255,27 @@ def _prepare_vulnerability_location(
         VulnerabilityLocation if asset is found, None otherwise.
     """
     asset: (
-        domain_name.DomainName | ios_store.IOSStore | android_store.AndroidStore | None
+        domain_name.DomainName
+        | ios_store.IOSStore
+        | android_store.AndroidStore
+        | repository_asset.Repository
+        | None
     ) = None
     metadata = []
-    if message.selector == "v3.asset.link":
+    if message.selector == "v3.asset.repository":
+        asset = repository_asset.Repository(
+            repository_url=str(message.data.get("repository_url") or ""),
+            commit_hash=str(message.data.get("commit_hash") or ""),
+        )
+        if path is not None:
+            metadata.append(
+                vuln_mixin.VulnerabilityLocationMetadata(
+                    metadata_type=vuln_mixin.MetadataType.FILE_PATH,
+                    value=path,
+                )
+            )
+
+    elif message.selector == "v3.asset.link":
         url = message.data.get("url")
         url_netloc = parse.urlparse(url).netloc
         asset = domain_name.DomainName(name=str(url_netloc))
@@ -272,7 +297,7 @@ def _prepare_vulnerability_location(
         metadata.append(
             vuln_mixin.VulnerabilityLocationMetadata(
                 metadata_type=vuln_mixin.MetadataType.FILE_PATH,
-                value=message.data.get("path") or "",
+                value=path or message.data.get("path") or "",
             )
         )
     else:
@@ -285,7 +310,7 @@ def _prepare_vulnerability_location(
         metadata.append(
             vuln_mixin.VulnerabilityLocationMetadata(
                 metadata_type=vuln_mixin.MetadataType.FILE_PATH,
-                value=message.data.get("path") or "",
+                value=path or message.data.get("path") or "",
             )
         )
 
@@ -339,8 +364,78 @@ class OSVAgent(
                 vulnerability_location=vulnerability_location,
             )
 
+    def _process_repository_asset(self, message: m.Message) -> None:
+        """Process message of type v3.asset.repository by scanning shared /code volume."""
+        repository_url = message.data.get("repository_url")
+        commit_hash = message.data.get("commit_hash")
+        logger.info(
+            "received repository asset url=%s commit=%s",
+            repository_url,
+            commit_hash,
+        )
+
+        repository_path = pathlib.Path(REPOSITORY_CODE_PATH)
+        if repository_path.is_dir() is False:
+            logger.error(
+                "Repository path %s is not available. Ensure shared volume is mounted.",
+                REPOSITORY_CODE_PATH,
+            )
+            return
+
+        supported_repository_files = [
+            file_path
+            for file_path in repository_path.rglob("*")
+            if file_path.is_file() is True
+            and file_path.name.lower() in SUPPORTED_OSV_FILE_NAMES_LOWER
+        ]
+
+        if len(supported_repository_files) == 0:
+            logger.info(
+                "No supported dependency files found in %s", REPOSITORY_CODE_PATH
+            )
+            return
+
+        for file_path in supported_repository_files:
+            try:
+                content = file_path.read_bytes()
+            except OSError as error:
+                logger.warning(
+                    "Failed to read repository file %s: %s", file_path, error
+                )
+                continue
+
+            relative_path = str(file_path.relative_to(repository_path))
+
+            if file_path.name in ("go.mod", "go.sum"):
+                scan_results = _run_osv_directory(str(file_path), content)
+            else:
+                scan_results = _run_osv(file_path.name, content)
+
+            if scan_results is None:
+                continue
+
+            parsed_output = osv_output_handler.parse_osv_output(
+                scan_results, self.api_key
+            )
+            if len(parsed_output) == 0:
+                continue
+
+            vulnerability_location = _prepare_vulnerability_location(
+                message,
+                path=relative_path,
+            )
+            self._emit_vulnerabilities(
+                output=parsed_output,
+                vulnerability_location=vulnerability_location,
+                path=relative_path,
+            )
+
     def _process_asset(self, message: m.Message) -> None:
-        """Process message of type v3.asset.file."""
+        """Process message of type v3.asset.file, v3.asset.link, or v3.asset.repository."""
+        if message.selector == "v3.asset.repository":
+            self._process_repository_asset(message)
+            return
+
         content = _get_content(message)
         path = _get_path(message)
         if content is None or content == b"":

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -406,7 +406,7 @@ class OSVAgent(
 
             relative_path = str(file_path.relative_to(repository_path))
 
-            if file_path.name in ("go.mod", "go.sum"):
+            if file_path.name.lower() in ("go.mod", "go.sum"):
                 scan_results = _run_osv_directory(str(file_path), content)
             else:
                 scan_results = _run_osv(file_path.name, content)

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -51,10 +51,6 @@ SUPPORTED_OSV_FILE_NAMES = [
     "verification-metadata.xml",
 ]
 
-SUPPORTED_OSV_FILE_NAMES_LOWER = {
-    file_name.lower() for file_name in SUPPORTED_OSV_FILE_NAMES
-}
-
 OSV_ECOSYSTEM_MAPPING = {
     "JAVASCRIPT_LIBRARY": ["npm"],
     "JAVA_LIBRARY": ["Maven"],
@@ -92,6 +88,22 @@ FILE_TYPE_BLACKLIST = (
 )
 
 REPOSITORY_CODE_PATH = "/code"
+
+REPOSITORY_DIR_BLACKLIST = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "vendor",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tox",
+    "dist",
+    "build",
+}
 
 logging.basicConfig(
     format="%(message)s",
@@ -226,6 +238,43 @@ def _run_osv_directory(original_path: str, content: bytes) -> str | None:
     except (OSError, UnicodeDecodeError, ValueError) as e:
         logger.error("Error during directory scan: %s", e, exc_info=True)
         return None
+
+
+def _run_osv_existing_directory(existing_path: str) -> str | None:
+    """Perform OSV scan on the parent directory of an existing file.
+
+    This is used for repository assets where files are already mounted on disk.
+    """
+    try:
+        existing_path_obj = pathlib.Path(existing_path)
+        module_dir = existing_path_obj.parent.resolve()
+        command = ["/usr/local/bin/osv-scanner", "--format", "json", str(module_dir)]
+        output = subprocess.run(
+            command, cwd=module_dir, capture_output=True, text=True, check=False
+        )
+        if _is_valid_osv_result(output.stdout):
+            return output.stdout
+        return None
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        logger.error("Error during existing directory scan: %s", e, exc_info=True)
+        return None
+
+
+def _scan_dependency_file(
+    file_name: str,
+    content: bytes,
+    file_path: str | None = None,
+    existing_on_disk: bool = False,
+) -> str | None:
+    """Scan one dependency file and route Go files to directory scans."""
+    normalized_file_name = file_name.lower()
+    if normalized_file_name in ("go.mod", "go.sum"):
+        if file_path is None:
+            return None
+        if existing_on_disk:
+            return _run_osv_existing_directory(file_path)
+        return _run_osv_directory(file_path, content)
+    return _run_osv(file_name, content)
 
 
 def _get_file_type(content: bytes, path: str | None) -> str:
@@ -382,52 +431,62 @@ class OSVAgent(
             )
             return
 
-        supported_repository_files = [
-            file_path
-            for file_path in repository_path.rglob("*")
-            if file_path.is_file() is True
-            and file_path.name.lower() in SUPPORTED_OSV_FILE_NAMES_LOWER
+        supported_file_names_lower = [
+            supported_file.lower() for supported_file in SUPPORTED_OSV_FILE_NAMES
         ]
+        found_supported_file = False
 
-        if len(supported_repository_files) == 0:
+        for root, dirs, files in os.walk(repository_path, topdown=True):
+            dirs[:] = [
+                directory
+                for directory in dirs
+                if directory not in REPOSITORY_DIR_BLACKLIST
+            ]
+
+            for file_name in files:
+                if file_name.lower() not in supported_file_names_lower:
+                    continue
+
+                found_supported_file = True
+                file_path = pathlib.Path(root) / file_name
+
+                try:
+                    content = file_path.read_bytes()
+                except OSError as error:
+                    logger.warning(
+                        "Failed to read repository file %s: %s", file_path, error
+                    )
+                    continue
+
+                relative_path = str(file_path.relative_to(repository_path))
+                scan_results = _scan_dependency_file(
+                    file_name=file_path.name,
+                    content=content,
+                    file_path=str(file_path),
+                    existing_on_disk=True,
+                )
+                if scan_results is None:
+                    continue
+
+                parsed_output = osv_output_handler.parse_osv_output(
+                    scan_results, self.api_key
+                )
+                if len(parsed_output) == 0:
+                    continue
+
+                vulnerability_location = _prepare_vulnerability_location(
+                    message,
+                    path=relative_path,
+                )
+                self._emit_vulnerabilities(
+                    output=parsed_output,
+                    vulnerability_location=vulnerability_location,
+                    path=relative_path,
+                )
+
+        if found_supported_file is False:
             logger.info(
                 "No supported dependency files found in %s", REPOSITORY_CODE_PATH
-            )
-            return
-
-        for file_path in supported_repository_files:
-            try:
-                content = file_path.read_bytes()
-            except OSError as error:
-                logger.warning(
-                    "Failed to read repository file %s: %s", file_path, error
-                )
-                continue
-
-            relative_path = str(file_path.relative_to(repository_path))
-
-            if file_path.name.lower() in ("go.mod", "go.sum"):
-                scan_results = _run_osv_directory(str(file_path), content)
-            else:
-                scan_results = _run_osv(file_path.name, content)
-
-            if scan_results is None:
-                continue
-
-            parsed_output = osv_output_handler.parse_osv_output(
-                scan_results, self.api_key
-            )
-            if len(parsed_output) == 0:
-                continue
-
-            vulnerability_location = _prepare_vulnerability_location(
-                message,
-                path=relative_path,
-            )
-            self._emit_vulnerabilities(
-                output=parsed_output,
-                vulnerability_location=vulnerability_location,
-                path=relative_path,
             )
 
     def _process_asset(self, message: m.Message) -> None:
@@ -450,21 +509,27 @@ class OSVAgent(
 
         # Special handling for Go module files to preserve directory context
         if path is not None and path.endswith(("go.mod", "go.sum")) is True:
-            scan_results = _run_osv_directory(path, content)
-            if scan_results is not None:
-                parsed_output = osv_output_handler.parse_osv_output(
-                    scan_results, self.api_key
+            scan_results = _scan_dependency_file(
+                file_name=pathlib.Path(path).name,
+                content=content,
+                file_path=path,
+            )
+            if scan_results is None:
+                return
+
+            parsed_output = osv_output_handler.parse_osv_output(
+                scan_results, self.api_key
+            )
+            if len(parsed_output) > 0:
+                vulnerability_location = _prepare_vulnerability_location(message)
+                self._emit_vulnerabilities(
+                    output=parsed_output,
+                    vulnerability_location=vulnerability_location,
                 )
-                if len(parsed_output) > 0:
-                    vulnerability_location = _prepare_vulnerability_location(message)
-                    self._emit_vulnerabilities(
-                        output=parsed_output,
-                        vulnerability_location=vulnerability_location,
-                    )
             return
 
         for file_name in SUPPORTED_OSV_FILE_NAMES:
-            scan_results = _run_osv(file_name, content)
+            scan_results = _scan_dependency_file(file_name=file_name, content=content)
             if scan_results is not None:
                 logger.info(
                     "Found valid name for file: %s in path: %s", file_name, path

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -8,6 +8,7 @@ in_selectors:
   - v3.asset.file
   - v3.fingerprint.file
   - v3.asset.link
+  - v3.asset.repository
 out_selectors:
   - v3.report.vulnerability
 args:
@@ -16,3 +17,7 @@ args:
     description: "NVD api key."
 docker_file_path : Dockerfile
 docker_build_root : .
+volumes:
+  - name: repository_code
+    path: /code
+    read_only: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,6 +310,17 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:test
 
 
 @pytest.fixture
+def repository_asset_message() -> message.Message:
+    """Creates a repository asset message for shared-volume repository scanning."""
+    selector = "v3.asset.repository"
+    msg_data = {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def fake_go_osv_output() -> str:
     """Return fake OSV output for Go module scanning."""
     return json.dumps(

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -1028,7 +1028,7 @@ def testRunOsvExistingDirectory_whenGoModExists_scansParentDirectory(
     fake_go_osv_output: str,
     tmp_path: Any,
 ) -> None:
-    """Unit test for _run_osv_existing_directory using an already existing go.mod."""
+    """Unit test for _run_osv_existing_directory with a go.mod path."""
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     go_mod_path = workspace_dir / "go.mod"
@@ -1044,7 +1044,9 @@ def testRunOsvExistingDirectory_whenGoModExists_scansParentDirectory(
     assert mock_subprocess_run.call_count == 1
     call_args = mock_subprocess_run.call_args
     assert call_args[0][0][0] == "/usr/local/bin/osv-scanner"
-    assert call_args[0][0][3] == str(workspace_dir)
+    assert call_args[0][0][1] == "--format"
+    assert call_args[0][0][2] == "json"
+    assert str(workspace_dir) in call_args[0][0][3]
 
 
 def testAgentOSV_whenRepositoryAssetHasGoMod_usesExistingDirectoryScan(
@@ -1055,11 +1057,12 @@ def testAgentOSV_whenRepositoryAssetHasGoMod_usesExistingDirectoryScan(
     mocker: plugin.MockerFixture,
     tmp_path: Any,
 ) -> None:
-    """Ensure repository go.mod is scanned from mounted directory without rewrite."""
+    """Ensure repository go.mod uses existing-directory scan rather than write-and-scan."""
     shared_code_path = tmp_path / "code"
     shared_code_path.mkdir()
-    go_mod_path = shared_code_path / "go.mod"
-    go_mod_path.write_text("module example.com/myapp\n", encoding="utf-8")
+    (shared_code_path / "go.mod").write_text(
+        "module example.com/myapp\n", encoding="utf-8"
+    )
 
     vuln_data = osv_output_handler.VulnData(
         package_name="github.com/gin-gonic/gin",
@@ -1074,16 +1077,16 @@ def testAgentOSV_whenRepositoryAssetHasGoMod_usesExistingDirectoryScan(
     )
 
     mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
-    directory_scan_mock = mocker.patch(
+    existing_scan_mock = mocker.patch(
         "agent.osv_agent._run_osv_existing_directory", return_value='{"results":[{}]}'
     )
-    run_osv_mock = mocker.patch("agent.osv_agent._run_osv")
+    directory_scan_mock = mocker.patch("agent.osv_agent._run_osv_directory")
     mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
 
     test_agent.process(repository_asset_message)
 
-    assert directory_scan_mock.call_count == 1
-    assert run_osv_mock.call_count == 0
+    assert existing_scan_mock.call_count == 1
+    assert directory_scan_mock.call_count == 0
     assert len(agent_mock) == 1
 
 
@@ -1095,17 +1098,14 @@ def testAgentOSV_whenRepositoryAssetHasBlacklistedDir_skipsNestedLockfiles(
     mocker: plugin.MockerFixture,
     tmp_path: Any,
 ) -> None:
-    """Ensure lockfiles under blacklisted directories are not scanned."""
+    """Ensure lockfiles under blacklisted dirs are ignored during repository scan."""
     shared_code_path = tmp_path / "code"
     shared_code_path.mkdir()
 
-    root_lockfile = shared_code_path / "package-lock.json"
-    root_lockfile.write_text('{"name": "demo-root"}', encoding="utf-8")
-
-    node_modules_dir = shared_code_path / "node_modules"
-    node_modules_dir.mkdir()
-    nested_lockfile = node_modules_dir / "package-lock.json"
-    nested_lockfile.write_text('{"name": "demo-nested"}', encoding="utf-8")
+    (shared_code_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    blacklisted_dir = shared_code_path / "node_modules"
+    blacklisted_dir.mkdir()
+    (blacklisted_dir / "package-lock.json").write_text("{}", encoding="utf-8")
 
     vuln_data = osv_output_handler.VulnData(
         package_name="lodash",
@@ -1129,3 +1129,7 @@ def testAgentOSV_whenRepositoryAssetHasBlacklistedDir_skipsNestedLockfiles(
 
     assert scan_mock.call_count == 1
     assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["vulnerability_location"]["metadata"][0]["value"]
+        == "package-lock.json"
+    )

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -1021,3 +1021,111 @@ def testAgentOSV_whenRepositoryVolumeMissing_shouldNotCrash(
     test_agent.process(repository_asset_message)
 
     assert len(agent_mock) == 0
+
+
+def testRunOsvExistingDirectory_whenGoModExists_scansParentDirectory(
+    mocker: plugin.MockerFixture,
+    fake_go_osv_output: str,
+    tmp_path: Any,
+) -> None:
+    """Unit test for _run_osv_existing_directory using an already existing go.mod."""
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    go_mod_path = workspace_dir / "go.mod"
+    go_mod_path.write_text("module example.com/myapp\n", encoding="utf-8")
+
+    mock_subprocess = mocker.Mock()
+    mock_subprocess.stdout = fake_go_osv_output
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=mock_subprocess)
+
+    result = osv_agent._run_osv_existing_directory(str(go_mod_path))
+
+    assert result == fake_go_osv_output
+    assert mock_subprocess_run.call_count == 1
+    call_args = mock_subprocess_run.call_args
+    assert call_args[0][0][0] == "/usr/local/bin/osv-scanner"
+    assert call_args[0][0][3] == str(workspace_dir)
+
+
+def testAgentOSV_whenRepositoryAssetHasGoMod_usesExistingDirectoryScan(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Ensure repository go.mod is scanned from mounted directory without rewrite."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    go_mod_path = shared_code_path / "go.mod"
+    go_mod_path.write_text("module example.com/myapp\n", encoding="utf-8")
+
+    vuln_data = osv_output_handler.VulnData(
+        package_name="github.com/gin-gonic/gin",
+        package_version="1.9.0",
+        risk="HIGH",
+        description="Test vulnerability in gin",
+        summary="Test vulnerability",
+        fixed_version="1.9.1",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    directory_scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv_existing_directory", return_value='{"results":[{}]}'
+    )
+    run_osv_mock = mocker.patch("agent.osv_agent._run_osv")
+    mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
+
+    test_agent.process(repository_asset_message)
+
+    assert directory_scan_mock.call_count == 1
+    assert run_osv_mock.call_count == 0
+    assert len(agent_mock) == 1
+
+
+def testAgentOSV_whenRepositoryAssetHasBlacklistedDir_skipsNestedLockfiles(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Ensure lockfiles under blacklisted directories are not scanned."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+
+    root_lockfile = shared_code_path / "package-lock.json"
+    root_lockfile.write_text('{"name": "demo-root"}', encoding="utf-8")
+
+    node_modules_dir = shared_code_path / "node_modules"
+    node_modules_dir.mkdir()
+    nested_lockfile = node_modules_dir / "package-lock.json"
+    nested_lockfile.write_text('{"name": "demo-nested"}', encoding="utf-8")
+
+    vuln_data = osv_output_handler.VulnData(
+        package_name="lodash",
+        package_version="4.7.11",
+        risk="HIGH",
+        description="Test vulnerability",
+        summary="Test vulnerability",
+        fixed_version="4.17.21",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv", return_value='{"results":[{}]}'
+    )
+    mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
+
+    test_agent.process(repository_asset_message)
+
+    assert scan_mock.call_count == 1
+    assert len(agent_mock) == 1

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -949,3 +949,74 @@ def testAgentOSV_whenGoModFileScanFails_doesNotEmit(
     test_agent.process(go_mod_file_message)
 
     assert len(agent_mock) == 0
+
+
+def testAgentOSV_whenRepositoryAsset_shouldScanSharedVolumeAndEmitVuln(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Ensure repository assets are scanned from shared volume and vulnerabilities are emitted."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    lockfile_path = shared_code_path / "package-lock.json"
+    lockfile_path.write_text('{"name": "demo"}', encoding="utf-8")
+
+    vuln_data = osv_output_handler.VulnData(
+        package_name="lodash",
+        package_version="4.7.11",
+        risk="HIGH",
+        description="Test vulnerability",
+        summary="Test vulnerability",
+        fixed_version="4.17.21",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv", return_value='{"results":[{}]}'
+    )
+    mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
+
+    test_agent.process(repository_asset_message)
+
+    assert scan_mock.call_count == 1
+    assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["vulnerability_location"]["repository"]["repository_url"]
+        == "https://github.com/org/repo.git"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["repository"]["commit_hash"]
+        == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["metadata"][0]["type"]
+        == "FILE_PATH"
+    )
+    assert agent_mock[0].data["vulnerability_location"]["metadata"][0]["value"] == str(
+        lockfile_path
+    )
+    assert agent_mock[0].data["dna"].endswith(f": {lockfile_path}")
+
+
+def testAgentOSV_whenRepositoryVolumeMissing_shouldNotCrash(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Ensure missing repository shared volume does not crash agent processing."""
+    missing_shared_path = tmp_path / "missing-code"
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(missing_shared_path))
+
+    test_agent.process(repository_asset_message)
+
+    assert len(agent_mock) == 0

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -999,10 +999,11 @@ def testAgentOSV_whenRepositoryAsset_shouldScanSharedVolumeAndEmitVuln(
         agent_mock[0].data["vulnerability_location"]["metadata"][0]["type"]
         == "FILE_PATH"
     )
-    assert agent_mock[0].data["vulnerability_location"]["metadata"][0]["value"] == str(
-        lockfile_path
+    assert (
+        agent_mock[0].data["vulnerability_location"]["metadata"][0]["value"]
+        == "package-lock.json"
     )
-    assert agent_mock[0].data["dna"].endswith(f": {lockfile_path}")
+    assert agent_mock[0].data["dna"].endswith(": package-lock.json")
 
 
 def testAgentOSV_whenRepositoryVolumeMissing_shouldNotCrash(


### PR DESCRIPTION
**Description**

Add `v3.asset.repository` support to `agent_osv` so the agent can scan dependency manifests from a shared repository volume and report vulnerabilities with repository-aware location metadata.

**Why**

`v3.asset.repository` assets only provide:
- `repository_url`
- `commit_hash`

To scan source dependencies, the agent must read lock/manifest files from the mounted repository code volume at runtime, then report findings with the scanned file path.

**What Changed**

**Repository Asset Handling**

- Added repository-asset flow in `OSVAgent` via `_process_repository_asset`
- Repository assets are now processed from the mounted code volume

**Repository Scanning**

- Recursively scans repository files under `code`
- Matches supported dependency files from `SUPPORTED_OSV_FILE_NAMES` (case-insensitive check)
- Skips noisy/unwanted directories using `REPOSITORY_DIR_BLACKLIST`
  - Examples:
    - `node_modules`
    - `vendor`
    - `.git`
    - build caches

For each supported file:
- Reads file bytes from disk

**Go-specific Fix for Read-only Volume**

Added `_run_osv_existing_directory(...)` for repository Go files:
- `go.mod`
- `go.sum`

This scans the existing module directory directly without rewriting files.

**Vulnerability Location Metadata**

For `v3.asset.repository`, vulnerability location now includes:

Repository asset metadata:
- `repository_url`
- `commit_hash`

Additional metadata:
- `FILE_PATH` with the repository-relative path of the scanned manifest

**Selectors and Volume**

- Added `v3.asset.repository` to supported input selectors
- Added shared volume mount at `code` (read-only) for repository source access

**Tests**

Added and updated tests to cover:
- Repository asset scanning and emission
- Missing volume handling
- Go repository scan via existing directory path
- Blacklist directory pruning behavior


**BUILD:**
<img width="1178" height="536" alt="image" src="https://github.com/user-attachments/assets/3d5d45e4-f491-4905-ae3d-65f461e1fab6" />


**RUN SCAN:**

<img width="1563" height="549" alt="image" src="https://github.com/user-attachments/assets/1ec3dcc5-f2c7-4ad3-a79a-35bd16938842" />
