### PR TITLE
fix: To avoid overriding dna for known CVE, we split findings with 0 CVEs and with CVEs.

### DIFF
--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -374,10 +374,11 @@ def construct_vuln(
                     f" has a security issue."
                 )
             title = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}"
+            dna = f"Use of Outdated Vulnerable Component with 0 CVE: {vuln.package_name}@{vuln.package_version}{f': {path}' if path is not None else ''}"
         else:
             vuln.cves.sort(reverse=True)
             title = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}: {', '.join(vuln.cves[:MAX_SHOWN_CVES])}"
-
+            dna = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}{f': {path}' if path is not None else ''}"
             if vuln.file_type is not None and vuln.file_name is not None:
                 description = (
                     f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
@@ -421,7 +422,7 @@ def construct_vuln(
                 targeted_by_nation_state=False,
                 recommendation=recommendation,
             ),
-            dna=f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}{f': {path}' if path is not None else ''}",
+            dna=dna,
             technical_detail=technical_detail,
             risk_rating=agent_report_vulnerability_mixin.RiskRating[
                 vuln.risk.upper()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,7 @@ def repository_asset_message() -> message.Message:
     msg_data = {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -561,7 +561,7 @@ def testAgentOSV_whenElfLibraryFingerprintMessage_shouldExcludeNpmEcosystemVulnz
     )
     assert (
         agent_mock[0].data["dna"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0"
+        == "Use of Outdated Vulnerable Component with 0 CVE: opencv@4.9.0"
     )
     assert agent_mock[0].data["risk_rating"] == "POTENTIALLY"
     assert agent_mock[0].data["technical_detail"] == (
@@ -601,7 +601,7 @@ def testAgentOSV_whenAndroidLibraryFingerprintMessage_shouldEmitVulnWithVulnLoca
     }
     assert (
         agent_mock[0].data["dna"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0: /workspace/go.mod"
+        == "Use of Outdated Vulnerable Component with 0 CVE: opencv@4.9.0: /workspace/go.mod"
     )
     assert agent_mock[0].data["risk_rating"] == "POTENTIALLY"
     assert agent_mock[0].data["technical_detail"] == (


### PR DESCRIPTION
Currently, Vulnz Matcher and OSV have the same DNA for a vulnerable component. OSV can report an outdated dependency with 0 CVEs, which will override the one from Vuln Matcher with CVEs.

This PR split the DNA between with and without CVEs.