### PR TITLE
fix: To avoid overriding dna for known cve, we skip findings with 0 CVEs.

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -297,6 +297,7 @@ def _prepare_vulnerability_location(
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
+            provider=str(message.data.get("provider") or ""),
         )
         if path is not None:
             metadata.append(

--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -353,6 +353,10 @@ def construct_vuln(
         Vulnerability entry.
     """
     for vuln in parsed_vulns:
+
+        if len(vuln.cves) == 0:
+            continue
+
         if vuln.fixed_version != "":
             recommendation = (
                 f"We recommend updating `{vuln.package_name}` to a version greater than or equal to "
@@ -361,34 +365,20 @@ def construct_vuln(
         else:
             recommendation = f"We recommend updating `{vuln.package_name}` to the latest available version."
 
-        if len(vuln.cves) == 0:
-            if vuln.file_type is not None and vuln.file_name is not None:
-                description = (
-                    f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
-                    f" found in the `{vuln.file_type}` `{vuln.file_name}` "
-                    f"has a security issue."
-                )
-            else:
-                description = (
-                    f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
-                    f" has a security issue."
-                )
-            title = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}"
-        else:
-            vuln.cves.sort(reverse=True)
-            title = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}: {', '.join(vuln.cves[:MAX_SHOWN_CVES])}"
+        vuln.cves.sort(reverse=True)
+        title = f"Use of Outdated Vulnerable Component: {vuln.package_name}@{vuln.package_version}: {', '.join(vuln.cves[:MAX_SHOWN_CVES])}"
 
-            if vuln.file_type is not None and vuln.file_name is not None:
-                description = (
-                    f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
-                    f" found in the `{vuln.file_type}` `{vuln.file_name}` "
-                    f"has a security issue.\nThe issue is identified by CVEs: `{', '.join(vuln.cves)}`."
-                )
-            else:
-                description = (
-                    f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
-                    f" has a security issue.\nThe issue is identified by CVEs: `{', '.join(vuln.cves)}`."
-                )
+        if vuln.file_type is not None and vuln.file_name is not None:
+            description = (
+                f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
+                f" found in the `{vuln.file_type}` `{vuln.file_name}` "
+                f"has a security issue.\nThe issue is identified by CVEs: `{', '.join(vuln.cves)}`."
+            )
+        else:
+            description = (
+                f"Dependency `{vuln.package_name}` with version `{vuln.package_version}`"
+                f" has a security issue.\nThe issue is identified by CVEs: `{', '.join(vuln.cves)}`."
+            )
 
         technical_detail = (
             f"#### Dependency `{vuln.package_name}`:\n"

--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -388,10 +388,7 @@ def construct_vuln(
         osv_description = vuln.description.replace(
             "## Recommendation\n\n", "Recommendation: "
         )
-        if len(vuln.cves) == 0:
-            technical_detail += f"- **Description**:\n```\n{osv_description}\n```"
-        else:
-            technical_detail += f"- **Description**:\n{osv_description}\n"
+        technical_detail += f"- **Description**:\n{osv_description}\n"
 
         short_description = f"Dependency `{vuln.package_name}` with version `{vuln.package_version}` has a security issue."
 

--- a/agent/osv_output_handler.py
+++ b/agent/osv_output_handler.py
@@ -353,7 +353,6 @@ def construct_vuln(
         Vulnerability entry.
     """
     for vuln in parsed_vulns:
-
         if len(vuln.cves) == 0:
             continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,7 @@ def repository_asset_message() -> message.Message:
     msg_data = {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -553,28 +553,7 @@ def testAgentOSV_whenElfLibraryFingerprintMessage_shouldExcludeNpmEcosystemVulnz
     """
     test_agent.process(elf_library_fingerprint_msg)
 
-    assert len(agent_mock) == 1
-
-    assert (
-        agent_mock[0].data["title"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0"
-    )
-    assert (
-        agent_mock[0].data["dna"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0"
-    )
-    assert agent_mock[0].data["risk_rating"] == "POTENTIALLY"
-    assert agent_mock[0].data["technical_detail"] == (
-        """#### Dependency `opencv`:\n- **Version**: `4.9.0`\n- **Description**:\n```\n- OSV-2022-394 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47190\n\n```\nCrash type: Incorrect-function-pointer-type\nCrash state:\ncv::split\ncv::split\nTestSplitAndMerge\n```\n\n- OSV-2023-444 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59450\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nopj_jp2_apply_pclr\nopj_jp2_decode\ncv::detail::Jpeg2KOpjDecoderBase::readData\n```\n\n\n```"""
-    )
-    assert agent_mock[0].data["description"] == (
-        """Dependency `opencv` with version `4.9.0` has a security issue."""
-    )
-
-    assert (
-        agent_mock[0].data["recommendation"]
-        == "We recommend updating `opencv` to the latest available version."
-    )
+    assert len(agent_mock) == 0
 
 
 def testAgentOSV_whenAndroidLibraryFingerprintMessage_shouldEmitVulnWithVulnLocation(
@@ -589,32 +568,7 @@ def testAgentOSV_whenAndroidLibraryFingerprintMessage_shouldEmitVulnWithVulnLoca
     """
     test_agent.process(android_library_finger_print)
 
-    assert len(agent_mock) == 1
-
-    assert (
-        agent_mock[0].data["title"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0"
-    )
-    assert agent_mock[0].data["vulnerability_location"] == {
-        "android_store": {"package_name": "com.app.package"},
-        "metadata": [{"type": "FILE_PATH", "value": "/workspace/go.mod"}],
-    }
-    assert (
-        agent_mock[0].data["dna"]
-        == "Use of Outdated Vulnerable Component: opencv@4.9.0: /workspace/go.mod"
-    )
-    assert agent_mock[0].data["risk_rating"] == "POTENTIALLY"
-    assert agent_mock[0].data["technical_detail"] == (
-        """#### Dependency `opencv`:\n- **Version**: `4.9.0`\n- **Location**: /workspace/go.mod\n- **Description**:\n```\n- OSV-2022-394 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47190\n\n```\nCrash type: Incorrect-function-pointer-type\nCrash state:\ncv::split\ncv::split\nTestSplitAndMerge\n```\n\n- OSV-2023-444 : OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59450\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nopj_jp2_apply_pclr\nopj_jp2_decode\ncv::detail::Jpeg2KOpjDecoderBase::readData\n```\n\n\n```"""
-    )
-    assert agent_mock[0].data["description"] == (
-        """Dependency `opencv` with version `4.9.0` has a security issue."""
-    )
-
-    assert (
-        agent_mock[0].data["recommendation"]
-        == "We recommend updating `opencv` to the latest available version."
-    )
+    assert len(agent_mock) == 0
 
 
 def testAgentOSV_whenUpperCaseApiEmptyLowerIsNot_returnsVulnz(
@@ -651,10 +605,12 @@ def testAgentOSV_whenUpperCaseApiEmptyLowerIsNot_returnsVulnz(
     assert (
         agent_mock[0]
         .data["technical_detail"]
-        .startswith("""#### Dependency `Wordpress`:
+        .startswith(
+            """#### Dependency `Wordpress`:
 - **Version**: `6.5.0`
 - **Description**:
-- [CVE-2024-31111](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-31111) : Improper Neutralization of Input During Web Page Generation (XSS or 'Cross-site Scripting') vulnerability in Automattic WordPress allows Stored XSS.This issue affects WordPress: from 6.5 through 6.5.4, from 6.4 through 6.4.4, from 6.3 through 6.3.4, from 6.2 through 6.2.5, from 6.1 through 6.1.6, from 6.0 through 6.0.8, from 5.9 through 5.9.9.""")
+- [CVE-2024-31111](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-31111) : Improper Neutralization of Input During Web Page Generation (XSS or 'Cross-site Scripting') vulnerability in Automattic WordPress allows Stored XSS.This issue affects WordPress: from 6.5 through 6.5.4, from 6.4 through 6.4.4, from 6.3 through 6.3.4, from 6.2 through 6.2.5, from 6.1 through 6.1.6, from 6.0 through 6.0.8, from 5.9 through 5.9.9."""
+        )
     )
     assert agent_mock[0].data["description"] == (
         "Dependency `Wordpress` with version `6.5.0` has a security issue.\n"


### PR DESCRIPTION
In case the findings have no CVEs, no need to report an empty, outdated dependency.