### PR TITLE
fix: Skip files with unsupported names instead of brute-forcing all formats

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -259,6 +259,25 @@ def _run_osv_existing_directory(existing_path: str) -> str | None:
         return None
 
 
+def _matched_supported_file_name(path: str | None) -> str | None:
+    """Return the canonical supported dependency file name matching the path basename.
+
+    Args:
+        path: The file path provided in the message.
+
+    Returns:
+        The canonical name from SUPPORTED_OSV_FILE_NAMES when the basename matches
+        (case-insensitive), otherwise None.
+    """
+    if path is None:
+        return None
+    basename = os.path.basename(path).lower()
+    for supported_name in SUPPORTED_OSV_FILE_NAMES:
+        if basename == supported_name.lower():
+            return supported_name
+    return None
+
+
 def _get_file_type(content: bytes, path: str | None) -> str:
     if path is None:
         mime = magic.from_buffer(content, mime=True)
@@ -497,7 +516,19 @@ class OSVAgent(
                     )
             return
 
-        for file_name in SUPPORTED_OSV_FILE_NAMES:
+        matched_file_name = _matched_supported_file_name(path)
+        if matched_file_name is not None:
+            # The message carries a known dependency file name, scan only that format.
+            candidate_file_names = [matched_file_name]
+        elif path is None:
+            # No file name to rely on, fall back to brute-forcing every format.
+            candidate_file_names = SUPPORTED_OSV_FILE_NAMES
+        else:
+            # A file name is present but is not a supported dependency file, skip it.
+            logger.info("File `%s` is not a supported dependency file, skipping.", path)
+            return
+
+        for file_name in candidate_file_names:
             scan_results = _run_osv(file_name, content)
             if scan_results is not None:
                 logger.info(

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -51,6 +51,8 @@ SUPPORTED_OSV_FILE_NAMES = [
     "verification-metadata.xml",
 ]
 
+_SUPPORTED_FILE_NAMES_LOWER = {name.lower(): name for name in SUPPORTED_OSV_FILE_NAMES}
+
 OSV_ECOSYSTEM_MAPPING = {
     "JAVASCRIPT_LIBRARY": ["npm"],
     "JAVA_LIBRARY": ["Maven"],
@@ -121,9 +123,7 @@ def _get_content_url(message: m.Message) -> bytes | None:
         return None
     parsed_url = parse.urlparse(url)
     filename = os.path.basename(parsed_url.path)
-    if filename.lower() in [
-        support_lock.lower() for support_lock in SUPPORTED_OSV_FILE_NAMES
-    ]:
+    if filename.lower() in _SUPPORTED_FILE_NAMES_LOWER:
         logger.debug("Found matching path %s", url)
         response = requests.get(url, timeout=60)
         logger.debug("Collected response %s", response.text)
@@ -272,10 +272,7 @@ def _matched_supported_file_name(path: str | None) -> str | None:
     if path is None:
         return None
     basename = os.path.basename(path).lower()
-    for supported_name in SUPPORTED_OSV_FILE_NAMES:
-        if basename == supported_name.lower():
-            return supported_name
-    return None
+    return _SUPPORTED_FILE_NAMES_LOWER.get(basename)
 
 
 def _get_file_type(content: bytes, path: str | None) -> str:
@@ -433,14 +430,13 @@ class OSVAgent(
             )
             return
 
-        supported_file_names_lower = {f.lower() for f in SUPPORTED_OSV_FILE_NAMES}
         found_supported_file = False
 
         for root, dirs, files in os.walk(repository_path, topdown=True):
             dirs[:] = [d for d in dirs if d.lower() not in REPOSITORY_DIR_BLACKLIST]
 
             for file_name in files:
-                if file_name.lower() not in supported_file_names_lower:
+                if file_name.lower() not in _SUPPORTED_FILE_NAMES_LOWER:
                     continue
 
                 found_supported_file = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,9 @@ SVG_CONTENT = b"""<svg xmlns="http://www.w3.org/2000/svg" width="100" height="10
 def scan_message_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"
-    content_path = f"{pathlib.Path(__file__).parent.parent}/tests/files/package_lock.json"
+    content_path = (
+        f"{pathlib.Path(__file__).parent.parent}/tests/files/package_lock.json"
+    )
     with open(content_path, "rb") as lock_file:
         msg_data = {
             "content": lock_file.read(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,12 @@ SVG_CONTENT = b"""<svg xmlns="http://www.w3.org/2000/svg" width="100" height="10
 def scan_message_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"
-    path = f"{pathlib.Path(__file__).parent.parent}/tests/files/package_lock.json"
-    with open(path, "rb") as lock_file:
-        msg_data = {"content": lock_file.read(), "path": path}
+    content_path = f"{pathlib.Path(__file__).parent.parent}/tests/files/package_lock.json"
+    with open(content_path, "rb") as lock_file:
+        msg_data = {
+            "content": lock_file.read(),
+            "path": f"{pathlib.Path(__file__).parent.parent}/tests/files/package-lock.json",
+        }
     return message.Message.from_data(selector, data=msg_data)
 
 
@@ -41,7 +44,7 @@ def scan_message_link() -> message.Message:
 def scan_message_bad_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"
-    path = f"{pathlib.Path(__file__).parent.parent}/tests/files/package_lock.json"
+    path = f"{pathlib.Path(__file__).parent.parent}/tests/files/package-lock.json"
     msg_data = {"content": b"\xdd\xff\x00", "path": path}
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -249,6 +249,29 @@ def testAgentOSV_whenAnalysisRunsWithNoFileName_shouldBruteForceTheName(
     assert len(agent_mock) == 1
 
 
+def testAgentOSV_whenFileNameIsNotSupported_shouldNotScanNorEmit(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A file carrying a non-dependency name (e.g. a markdown note) must be skipped
+    instead of being brute-forced against every supported format."""
+    subprocess_mock = mocker.patch("agent.osv_agent._run_command")
+    message_markdown_file = message.Message.from_data(
+        "v3.asset.file",
+        data={
+            "content": b"# Notes\nsome documentation mentioning requirements.txt",
+            "path": "/workspace/notes/reconnaissance-template-inventory.md",
+        },
+    )
+
+    test_agent.process(message_markdown_file)
+
+    assert subprocess_mock.call_count == 0
+    assert len(agent_mock) == 0
+
+
 def testAgentOSV_withContentUrl_shouldDownloadFileContentAndBrutForceTheFileName(
     test_agent: osv_agent.OSVAgent,
     agent_mock: list[message.Message],
@@ -644,7 +667,7 @@ def testAgentOSV_whenIosMetadataWithBundleId_prepareVulnerabilityLocation(
     selector = "v3.asset.file"
     msg_data = {
         "content": b"some file content",
-        "path": "/tmp/path/file.txt",
+        "path": "/tmp/path/requirements.txt",
         "ios_metadata": {"bundle_id": "com.example.app"},
     }
     msg = message.Message.from_data(selector, data=msg_data)
@@ -672,7 +695,7 @@ def testAgentOSV_whenIosMetadataWithBundleId_prepareVulnerabilityLocation(
         .data.get("vulnerability_location", {})
         .get("metadata", [{}])[0]
         .get("value")
-        == "/tmp/path/file.txt"
+        == "/tmp/path/requirements.txt"
     )
 
 
@@ -701,7 +724,7 @@ def testAgentOSV_whenAndroidMetadataWithPackageName_prepareVulnerabilityLocation
     selector = "v3.asset.file"
     msg_data = {
         "content": b"some file content",
-        "path": "/tmp/path/file.txt",
+        "path": "/tmp/path/requirements.txt",
         "android_metadata": {"package_name": "com.example.app"},
     }
     msg = message.Message.from_data(selector, data=msg_data)
@@ -729,7 +752,7 @@ def testAgentOSV_whenAndroidMetadataWithPackageName_prepareVulnerabilityLocation
         .data.get("vulnerability_location", {})
         .get("metadata", [{}])[0]
         .get("value")
-        == "/tmp/path/file.txt"
+        == "/tmp/path/requirements.txt"
     )
 
 


### PR DESCRIPTION
## Problem

The OSV agent ignored the message file name and ran **every** supported lockfile format (20 formats × 2 commands = 40 osv-scanner invocations) against any non-blacklisted file. When fed documentation/text files (e.g. markdown notes under `/workspace/notes/*.md`), it brute-forced all formats and produced a flood of `OSV scan returned no results` warnings plus wasted scans:

```
INFO  Found valid name for file: buildscript-gradle.lockfile in path: /workspace/notes/reconnaissance-template-inventory.md
WARNING OSV scan returned no results for command [... '--lockfile', 'Cargo.lock']
WARNING OSV scan returned no results for command [... '--sbom', 'Cargo.lock']
... (repeated for all 20 formats, per file)
```

`.md`/text files aren't in `FILE_TYPE_BLACKLIST`, so nothing stopped them.

## Fix

The brute-force was only ever meant as a fallback for files delivered without a name (raw `content` / `content_url`). The agent now decides based on the file name:

- **Name matches a supported lockfile** → scan only that format.
- **No file name available** (`path` is `None`) → keep the legacy brute-force fallback.
- **Name present but not a supported dependency file** → skip with a single log line.

Added helper `_matched_supported_file_name(path)` that matches the basename case-insensitively against `SUPPORTED_OSV_FILE_NAMES`.

## Tests

- New regression test `testAgentOSV_whenFileNameIsNotSupported_shouldNotScanNorEmit` (markdown note → zero scans, zero emissions).
- Updated `scan_message_file` / `scan_message_bad_file` fixtures so the message `path` uses the real `package-lock.json` name.
- Switched the two iOS/Android `prepareVulnerabilityLocation` tests from an arbitrary `file.txt` to `requirements.txt` so the agent actually scans (their subject — metadata location — is unchanged).

`35 passed`, ruff clean.

## Out of scope

Does not touch the repository-asset path (juice-shop returning "No supported dependency files found" is correct — that repo commits no lockfile).