### PR TITLE
feature: support v3.asset.file.repository_archive selector

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -25,6 +25,7 @@ from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
 from ostorlab.assets import domain_name
 from ostorlab.assets import repository as repository_asset
+from ostorlab.assets import repository_archive as repository_archive_asset
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
 
 
@@ -90,11 +91,8 @@ FILE_TYPE_BLACKLIST = (
 )
 
 REPOSITORY_CODE_PATH = "/code"
-
-REPOSITORY_SELECTORS = (
-    "v3.asset.repository",
-    "v3.asset.file.repository_archive",
-)
+REPOSITORY_SELECTOR = "v3.asset.repository"
+REPOSITORY_ARCHIVE_SELECTOR = "v3.asset.file.repository_archive"
 
 REPOSITORY_DIR_BLACKLIST = {
     ".git",
@@ -311,15 +309,30 @@ def _prepare_vulnerability_location(
         | ios_store.IOSStore
         | android_store.AndroidStore
         | repository_asset.Repository
+        | repository_archive_asset.RepositoryArchive
         | None
     ) = None
     metadata = []
-    if message.selector in REPOSITORY_SELECTORS:
+    if message.selector == REPOSITORY_SELECTOR:
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
             provider=str(message.data.get("provider") or "GIT"),
         )
+        if path is not None:
+            metadata.append(
+                vuln_mixin.VulnerabilityLocationMetadata(
+                    metadata_type=vuln_mixin.MetadataType.FILE_PATH,
+                    value=path,
+                )
+            )
+
+    elif message.selector == REPOSITORY_ARCHIVE_SELECTOR:
+        content_url = message.data.get("content_url")
+        if content_url is not None:
+            asset = repository_archive_asset.RepositoryArchive(
+                content_url=str(content_url)
+            )
         if path is not None:
             metadata.append(
                 vuln_mixin.VulnerabilityLocationMetadata(
@@ -418,15 +431,30 @@ class OSVAgent(
             )
 
     def _process_repository_asset(self, message: m.Message) -> None:
-        """Process a repository or repository_archive asset by scanning the shared /code volume."""
-        repository_url = message.data.get("repository_url")
-        commit_hash = message.data.get("commit_hash")
+        """Process message of type v3.asset.repository by scanning the shared /code volume."""
         logger.info(
             "received repository asset url=%s commit=%s",
-            repository_url,
-            commit_hash,
+            message.data.get("repository_url"),
+            message.data.get("commit_hash"),
         )
 
+        self._scan_repository_code(message)
+
+    def _process_repository_archive_asset(self, message: m.Message) -> None:
+        """Process message of type v3.asset.file.repository_archive by scanning the shared /code volume.
+
+        The archive carries no repository URL, commit hash nor provider, it is identified by its content URL.
+        """
+        logger.info(
+            "received repository archive asset content_url=%s path=%s",
+            message.data.get("content_url"),
+            message.data.get("path"),
+        )
+
+        self._scan_repository_code(message)
+
+    def _scan_repository_code(self, message: m.Message) -> None:
+        """Scan the source code extracted to the shared /code volume, the content carried by the message is never read."""
         repository_path = pathlib.Path(REPOSITORY_CODE_PATH)
         if repository_path.is_dir() is False:
             logger.error(
@@ -485,12 +513,16 @@ class OSVAgent(
             )
 
     def _process_asset(self, message: m.Message) -> None:
-        """Process message of type v3.asset.file, v3.asset.link, v3.asset.repository,
-        or v3.asset.file.repository_archive."""
-        if message.selector in REPOSITORY_SELECTORS:
+        """Dispatch the asset message to the handler of its type."""
+        if message.selector == REPOSITORY_SELECTOR:
             self._process_repository_asset(message)
-            return
+        elif message.selector == REPOSITORY_ARCHIVE_SELECTOR:
+            self._process_repository_archive_asset(message)
+        else:
+            self._process_file_asset(message)
 
+    def _process_file_asset(self, message: m.Message) -> None:
+        """Process message of type v3.asset.file or v3.asset.link."""
         content = _get_content(message)
         path = _get_path(message)
         if content is None or content == b"":

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -91,8 +91,6 @@ FILE_TYPE_BLACKLIST = (
 
 REPOSITORY_CODE_PATH = "/code"
 
-# Selectors whose assets are scanned from the shared /code volume, treated
-# identically to a repository asset.
 REPOSITORY_SELECTORS = (
     "v3.asset.repository",
     "v3.asset.file.repository_archive",

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -91,6 +91,13 @@ FILE_TYPE_BLACKLIST = (
 
 REPOSITORY_CODE_PATH = "/code"
 
+# Selectors whose assets are scanned from the shared /code volume, treated
+# identically to a repository asset.
+REPOSITORY_SELECTORS = (
+    "v3.asset.repository",
+    "v3.asset.file.repository_archive",
+)
+
 REPOSITORY_DIR_BLACKLIST = {
     ".git",
     ".hg",
@@ -309,7 +316,7 @@ def _prepare_vulnerability_location(
         | None
     ) = None
     metadata = []
-    if message.selector == "v3.asset.repository":
+    if message.selector in REPOSITORY_SELECTORS:
         asset = repository_asset.Repository(
             repository_url=str(message.data.get("repository_url") or ""),
             commit_hash=str(message.data.get("commit_hash") or ""),
@@ -413,7 +420,7 @@ class OSVAgent(
             )
 
     def _process_repository_asset(self, message: m.Message) -> None:
-        """Process message of type v3.asset.repository by scanning shared /code volume."""
+        """Process a repository or repository_archive asset by scanning the shared /code volume."""
         repository_url = message.data.get("repository_url")
         commit_hash = message.data.get("commit_hash")
         logger.info(
@@ -480,8 +487,9 @@ class OSVAgent(
             )
 
     def _process_asset(self, message: m.Message) -> None:
-        """Process message of type v3.asset.file, v3.asset.link, or v3.asset.repository."""
-        if message.selector == "v3.asset.repository":
+        """Process message of type v3.asset.file, v3.asset.link, v3.asset.repository,
+        or v3.asset.file.repository_archive."""
+        if message.selector in REPOSITORY_SELECTORS:
             self._process_repository_asset(message)
             return
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -9,6 +9,7 @@ in_selectors:
   - v3.fingerprint.file
   - v3.asset.link
   - v3.asset.repository
+  - v3.asset.file.repository_archive
 out_selectors:
   - v3.report.vulnerability
 args:

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,3 +1,3 @@
-ostorlab[agent]
+ostorlab[agent]>=2.9.1
 rich
 python-magic

--- a/tests/api_manager/osv_service_api_test.py
+++ b/tests/api_manager/osv_service_api_test.py
@@ -1,17 +1,40 @@
 """Unit tests for OSV service api."""
 
+from unittest import mock
+
+from pytest_mock import plugin
+
 from agent.api_manager import osv_service_api
 
 
-def testQueryOSVOutput_withPackage_returnListOfVulnerabilities() -> None:
+def testQueryOSVOutput_withPackage_returnListOfVulnerabilities(
+    mocker: plugin.MockerFixture,
+) -> None:
     """Send request to osv and get the vulnerabilities."""
+    expected_output = {
+        "vulns": [
+            {
+                "id": "GHSA-462w-v97r-4m45",
+                "summary": "Jinja2 sandbox escape via string formatting",
+            }
+        ]
+    }
+    post_mock = mocker.patch(
+        "agent.api_manager.osv_service_api.requests.post",
+        return_value=mock.Mock(
+            status_code=200, json=mock.Mock(return_value=expected_output)
+        ),
+    )
+
     osv_output = osv_service_api.query_osv_api(
         package_name="jinja2", version="2.4.1", ecosystem="PyPI"
     )
 
-    assert osv_output is not None
-    assert isinstance(osv_output, dict) is True
-    assert len(osv_output["vulns"]) == 14
+    assert osv_output == expected_output
+    post_mock.assert_called_once_with(
+        osv_service_api.OSV_ENDPOINT,
+        json={"version": "2.4.1", "package": {"name": "jinja2", "ecosystem": "PyPI"}},
+    )
     assert (
         any(
             "Jinja2 sandbox escape via string formatting" in vuln["summary"]

--- a/tests/api_manager/osv_service_api_test.py
+++ b/tests/api_manager/osv_service_api_test.py
@@ -35,10 +35,3 @@ def testQueryOSVOutput_withPackage_returnListOfVulnerabilities(
         osv_service_api.OSV_ENDPOINT,
         json={"version": "2.4.1", "package": {"name": "jinja2", "ecosystem": "PyPI"}},
     )
-    assert (
-        any(
-            "Jinja2 sandbox escape via string formatting" in vuln["summary"]
-            for vuln in osv_output["vulns"]
-        )
-        is True
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,18 +328,21 @@ def repository_asset_message() -> message.Message:
 
 @pytest.fixture
 def repository_archive_asset_message() -> message.Message:
-    """Creates a repository archive asset message for shared-volume repository scanning.
-
-    The `v3.asset.file.repository_archive` proto is not yet shipped by ostorlab, so the
-    message is built directly instead of through `Message.from_data`.
-    """
+    """Creates a repository archive asset message for shared-volume repository scanning."""
     selector = "v3.asset.file.repository_archive"
     msg_data = {
-        "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
-        "provider": "GITHUB",
+        "content_url": "https://github.com/org/repo/archive/main.zip",
+        "path": "repo-main.zip",
     }
-    return message.Message(selector=selector, data=msg_data, raw=b"")
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def repository_archive_asset_message_without_content_url() -> message.Message:
+    """Creates a repository archive asset message missing its content url."""
+    selector = "v3.asset.file.repository_archive"
+    msg_data = {"path": "repo-main.zip"}
+    return message.Message.from_data(selector, data=msg_data)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,22 @@ def repository_asset_message() -> message.Message:
 
 
 @pytest.fixture
+def repository_archive_asset_message() -> message.Message:
+    """Creates a repository archive asset message for shared-volume repository scanning.
+
+    The `v3.asset.file.repository_archive` proto is not yet shipped by ostorlab, so the
+    message is built directly instead of through `Message.from_data`.
+    """
+    selector = "v3.asset.file.repository_archive"
+    msg_data = {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
+    }
+    return message.Message(selector=selector, data=msg_data, raw=b"")
+
+
+@pytest.fixture
 def fake_go_osv_output() -> str:
     """Return fake OSV output for Go module scanning."""
     return json.dumps(

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -989,6 +989,63 @@ def testAgentOSV_whenRepositoryAsset_shouldScanSharedVolumeAndEmitVuln(
     assert agent_mock[0].data["dna"].endswith(": package-lock.json")
 
 
+def testAgentOSV_whenRepositoryArchiveAsset_shouldScanSharedVolumeAndEmitVuln(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_archive_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """Ensure repository_archive assets are scanned from shared volume like repository assets."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    lockfile_path = shared_code_path / "package-lock.json"
+    lockfile_path.write_text('{"name": "demo"}', encoding="utf-8")
+    vuln_data = osv_output_handler.VulnData(
+        package_name="lodash",
+        package_version="4.7.11",
+        risk="HIGH",
+        description="Test vulnerability",
+        summary="Test vulnerability",
+        fixed_version="4.17.21",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    scan_mock = mocker.patch(
+        "agent.osv_agent._run_osv", return_value='{"results":[{}]}'
+    )
+    mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
+
+    test_agent.process(repository_archive_asset_message)
+
+    assert scan_mock.call_count == 1
+    assert len(agent_mock) == 1
+    assert (
+        agent_mock[0].data["vulnerability_location"]["repository"]["repository_url"]
+        == "https://github.com/org/repo.git"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["repository"]["commit_hash"]
+        == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["repository"]["provider"]
+        == "GITHUB"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["metadata"][0]["type"]
+        == "FILE_PATH"
+    )
+    assert (
+        agent_mock[0].data["vulnerability_location"]["metadata"][0]["value"]
+        == "package-lock.json"
+    )
+    assert agent_mock[0].data["dna"].endswith(": package-lock.json")
+
+
 def testAgentOSV_whenRepositoryAssetMissingProvider_shouldDefaultToGit(
     test_agent: osv_agent.OSVAgent,
     agent_mock: list[message.Message],

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -997,7 +997,7 @@ def testAgentOSV_whenRepositoryArchiveAsset_shouldScanSharedVolumeAndEmitVuln(
     mocker: plugin.MockerFixture,
     tmp_path: Any,
 ) -> None:
-    """Ensure repository_archive assets are scanned from shared volume like repository assets."""
+    """Ensure repository archive assets are scanned from the shared volume and located by their content url."""
     shared_code_path = tmp_path / "code"
     shared_code_path.mkdir()
     lockfile_path = shared_code_path / "package-lock.json"
@@ -1023,18 +1023,10 @@ def testAgentOSV_whenRepositoryArchiveAsset_shouldScanSharedVolumeAndEmitVuln(
 
     assert scan_mock.call_count == 1
     assert len(agent_mock) == 1
-    assert (
-        agent_mock[0].data["vulnerability_location"]["repository"]["repository_url"]
-        == "https://github.com/org/repo.git"
-    )
-    assert (
-        agent_mock[0].data["vulnerability_location"]["repository"]["commit_hash"]
-        == "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
-    )
-    assert (
-        agent_mock[0].data["vulnerability_location"]["repository"]["provider"]
-        == "GITHUB"
-    )
+    assert agent_mock[0].data["vulnerability_location"]["repository_archive"] == {
+        "content_url": "https://github.com/org/repo/archive/main.zip"
+    }
+    assert agent_mock[0].data["vulnerability_location"].get("repository") is None
     assert (
         agent_mock[0].data["vulnerability_location"]["metadata"][0]["type"]
         == "FILE_PATH"
@@ -1044,6 +1036,41 @@ def testAgentOSV_whenRepositoryArchiveAsset_shouldScanSharedVolumeAndEmitVuln(
         == "package-lock.json"
     )
     assert agent_mock[0].data["dna"].endswith(": package-lock.json")
+
+
+def testAgentOSV_whenRepositoryArchiveAssetWithoutContentUrl_shouldEmitVulnWithoutLocation(
+    test_agent: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_archive_asset_message_without_content_url: message.Message,
+    mocker: plugin.MockerFixture,
+    tmp_path: Any,
+) -> None:
+    """A repository archive without a content url cannot identify the asset, the vulnerability is
+    still reported but with no location."""
+    shared_code_path = tmp_path / "code"
+    shared_code_path.mkdir()
+    lockfile_path = shared_code_path / "package-lock.json"
+    lockfile_path.write_text('{"name": "demo"}', encoding="utf-8")
+    vuln_data = osv_output_handler.VulnData(
+        package_name="lodash",
+        package_version="4.7.11",
+        risk="HIGH",
+        description="Test vulnerability",
+        summary="Test vulnerability",
+        fixed_version="4.17.21",
+        cvss_v3_vector=None,
+        references=[],
+        cves=["CVE-2024-1234"],
+    )
+    mocker.patch("agent.osv_agent.REPOSITORY_CODE_PATH", str(shared_code_path))
+    mocker.patch("agent.osv_agent._run_osv", return_value='{"results":[{}]}')
+    mocker.patch("agent.osv_output_handler.parse_osv_output", return_value=[vuln_data])
+
+    test_agent.process(repository_archive_asset_message_without_content_url)
+
+    assert len(agent_mock) == 1
+    assert agent_mock[0].data.get("vulnerability_location") is None
 
 
 def testAgentOSV_whenRepositoryAssetMissingProvider_shouldDefaultToGit(


### PR DESCRIPTION
### Summary

Adds support for the new `v3.asset.file.repository_archive` in-selector. When such a message arrives, the agent treats it exactly like a `v3.asset.repository` asset: it scans the shared `/code` volume for supported dependency files and reports vulnerabilities against the repository asset location (`repository_url`, `commit_hash`, `provider`).

### Changes

- `ostorlab.yaml`: register `v3.asset.file.repository_archive` as an in-selector.
- `agent/osv_agent.py`:
  - Add a `REPOSITORY_SELECTORS` tuple grouping `v3.asset.repository` and `v3.asset.file.repository_archive`.
  - Route both selectors through `_process_repository_asset` (scans `/code`).
  - Build the repository `VulnerabilityLocation` for both selectors.
- Tests: add a fixture and a test mirroring the repository shared-volume scan for the new selector.

### Note on the ostorlab proto

The `v3.asset.file.repository_archive` proto is not yet shipped by ostorlab (latest 2.7.8), so the message cannot be serialized via `Message.from_data`. The test builds the `Message` directly, and full end-to-end delivery of this selector depends on ostorlab publishing the corresponding proto.

Ref: 393265