### PR TITLE
feature: Add exclude paths 

### DIFF
--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -121,24 +121,26 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def _should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+def _should_exclude_path(
+    path: str | None, exclude_path_regexes: list[str] | None
+) -> bool:
     """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of regex patterns to match against the path.
+        exclude_path_regexes: List of regex patterns to match against the path.
 
     Returns:
         True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
-    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+    if path is None or exclude_path_regexes is None or len(exclude_path_regexes) == 0:
         return False
-    for pattern in exclude_paths:
+    for pattern in exclude_path_regexes:
         try:
             matched = re.search(pattern, path)
         except re.error as e:
-            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            logger.warning("Invalid exclude_path_regexes regex %r: %s", pattern, e)
             continue
         if matched is not None:
             logger.info(
@@ -551,10 +553,10 @@ class OSVAgent(
 
     def _process_file_asset(self, message: m.Message) -> None:
         """Process message of type v3.asset.file or v3.asset.link."""
-        content = _get_content(message)
         path = _get_path(message)
-        if _should_exclude_path(path, self.args.get("exclude_paths")) is True:
+        if _should_exclude_path(path, self.args.get("exclude_path_regexes")) is True:
             return
+        content = _get_content(message)
         if content is None or content == b"":
             logger.warning("Message file content is empty.")
             return

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -120,6 +120,28 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+    """Report whether a file path starts with one of the excluded prefixes.
+
+    Args:
+        path: The file path reported in the message, or None.
+        exclude_paths: List of path prefixes to match against the path.
+
+    Returns:
+        True if the path starts with at least one prefix and should be skipped,
+        False otherwise.
+    """
+    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+        return False
+    for prefix in exclude_paths:
+        if path.startswith(prefix) is True:
+            logger.info(
+                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+            )
+            return True
+    return False
+
+
 def _get_content_url(message: m.Message) -> bytes | None:
     url = message.data.get("url")
     if url is None:
@@ -525,6 +547,8 @@ class OSVAgent(
         """Process message of type v3.asset.file or v3.asset.link."""
         content = _get_content(message)
         path = _get_path(message)
+        if _should_exclude_path(path, self.args.get("exclude_paths")) is True:
+            return
         if content is None or content == b"":
             logger.warning("Message file content is empty.")
             return

--- a/agent/osv_agent.py
+++ b/agent/osv_agent.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import pathlib
+import re
 import subprocess
 import typing
 import os
@@ -121,22 +122,27 @@ logger = logging.getLogger(__name__)
 
 
 def _should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
-    """Report whether a file path starts with one of the excluded prefixes.
+    """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of path prefixes to match against the path.
+        exclude_paths: List of regex patterns to match against the path.
 
     Returns:
-        True if the path starts with at least one prefix and should be skipped,
+        True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
     if path is None or exclude_paths is None or len(exclude_paths) == 0:
         return False
-    for prefix in exclude_paths:
-        if path.startswith(prefix) is True:
+    for pattern in exclude_paths:
+        try:
+            matched = re.search(pattern, path)
+        except re.error as e:
+            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            continue
+        if matched is not None:
             logger.info(
-                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+                "Skipping file %s: path matches exclude pattern %r.", path, pattern
             )
             return True
     return False

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -16,6 +16,9 @@ args:
   - name: "nvd_api_key"
     type: "string"
     description: "NVD api key."
+  - name: "exclude_paths"
+    type: "array"
+    description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path : Dockerfile
 docker_build_root : .
 volumes:

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -16,7 +16,7 @@ args:
   - name: "nvd_api_key"
     type: "string"
     description: "NVD api key."
-  - name: "exclude_paths"
+  - name: "exclude_path_regexes"
     type: "array"
     description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path : Dockerfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.agent.message import message
 from ostorlab.runtimes import definitions as runtime_definitions
+from ostorlab.utils import definitions as utils_definitions
 
 from agent import osv_agent
 
@@ -87,11 +88,11 @@ def test_agent_with_exclude_paths(
             bus_url="NA",
             bus_exchange_topic="NA",
             args=[
-                {
-                    "name": "exclude_paths",
-                    "type": "array",
-                    "value": [r"^/workspace(/|$)"],
-                }
+                utils_definitions.Arg(
+                    name="exclude_paths",
+                    type="array",
+                    value=json.dumps([r"^/workspace(/|$)"]).encode(),
+                )
             ],
             healthcheck_port=random.randint(5000, 6000),
             redis_url="redis://guest:guest@localhost:6379",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def workspace_scan_message_file() -> message.Message:
 
 
 @pytest.fixture()
-def test_agent_with_exclude_paths(
+def test_agent_with_exclude_path_regexes(
     agent_persist_mock: Dict[str | bytes, str | bytes],
 ) -> osv_agent.OSVAgent:
     """OSV agent configured to exclude files under /workspace."""
@@ -89,7 +89,7 @@ def test_agent_with_exclude_paths(
             bus_exchange_topic="NA",
             args=[
                 utils_definitions.Arg(
-                    name="exclude_paths",
+                    name="exclude_path_regexes",
                     type="array",
                     value=json.dumps([r"^/workspace(/|$)"]).encode(),
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,38 @@ def invalid_scan_message_file() -> message.Message:
 
 
 @pytest.fixture
+def workspace_scan_message_file() -> message.Message:
+    """Creates a v3.asset.file message whose path is under the excluded /workspace tree."""
+    selector = "v3.asset.file"
+    msg_data = {"content": b'{"name": "test"}', "path": "/workspace/package-lock.json"}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def test_agent_with_exclude_paths(
+    agent_persist_mock: Dict[str | bytes, str | bytes],
+) -> osv_agent.OSVAgent:
+    """OSV agent configured to exclude files under /workspace."""
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        settings = runtime_definitions.AgentSettings(
+            key="agent/ostorlab/osv",
+            bus_url="NA",
+            bus_exchange_topic="NA",
+            args=[
+                {
+                    "name": "exclude_paths",
+                    "type": "array",
+                    "value": [r"^/workspace(/|$)"],
+                }
+            ],
+            healthcheck_port=random.randint(5000, 6000),
+            redis_url="redis://guest:guest@localhost:6379",
+        )
+        return osv_agent.OSVAgent(definition, settings)
+
+
+@pytest.fixture
 def blacklisted_scan_message_file() -> message.Message:
     """Creates an invalid message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -191,7 +191,7 @@ def testAgentOSV_whenAnalysisRunsWithInvalidFile_notProcessMessage(
 
 
 def testAgentOSV_whenFilePathIsExcluded_notProcessMessage(
-    test_agent_with_exclude_paths: osv_agent.OSVAgent,
+    test_agent_with_exclude_path_regexes: osv_agent.OSVAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     workspace_scan_message_file: message.Message,
@@ -200,7 +200,7 @@ def testAgentOSV_whenFilePathIsExcluded_notProcessMessage(
     """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
     subprocess_mock = mocker.patch("agent.osv_agent._run_command")
 
-    test_agent_with_exclude_paths.process(workspace_scan_message_file)
+    test_agent_with_exclude_path_regexes.process(workspace_scan_message_file)
 
     assert subprocess_mock.call_count == 0
     assert len(agent_mock) == 0

--- a/tests/osv_agent_test.py
+++ b/tests/osv_agent_test.py
@@ -190,6 +190,22 @@ def testAgentOSV_whenAnalysisRunsWithInvalidFile_notProcessMessage(
     assert len(agent_mock) == 0
 
 
+def testAgentOSV_whenFilePathIsExcluded_notProcessMessage(
+    test_agent_with_exclude_paths: osv_agent.OSVAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    workspace_scan_message_file: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
+    subprocess_mock = mocker.patch("agent.osv_agent._run_command")
+
+    test_agent_with_exclude_paths.process(workspace_scan_message_file)
+
+    assert subprocess_mock.call_count == 0
+    assert len(agent_mock) == 0
+
+
 def testAgentOSV_whenAnalysisRunsWithBlackListedFile_notProcessMessage(
     test_agent: osv_agent.OSVAgent,
     agent_mock: list[message.Message],


### PR DESCRIPTION
# Add exclude_path_regexes arg to skip files by regex pattern

Adds a new `exclude_path_regexes` arg (list of regex patterns). When a `v3.asset.file` message has a path that matches one of the patterns, the agent logs and skips the file instead of scanning it.

- New `exclude_path_regexes` arg in `ostorlab.yaml`.
- File processing skips any path matching an excluded pattern.


